### PR TITLE
[Bug] Friendship-based moves have Base Power -1 when Pokemon is wild

### DIFF
--- a/src/data/move.ts
+++ b/src/data/move.ts
@@ -3036,9 +3036,10 @@ export class FriendshipPowerAttr extends VariablePowerAttr {
 
     if (user instanceof PlayerPokemon) {
       const friendshipPower = Math.floor(Math.min(user.friendship, 255) / 2.5);
-      power.value = Math.max(!this.invert ? friendshipPower : 102 - friendshipPower, 1);
+      power.value = !this.invert ? friendshipPower : 102 - friendshipPower;
     }
 
+    power.value = Math.max(power.value, 1);
     return true;
   }
 }


### PR DESCRIPTION
See [here](https://discord.com/channels/1125469663833370665/1251763288870617108/1251773485269909666) for a Discord thread with more details.